### PR TITLE
Fix bug where non-root group ID is accepted with root_is_site = False

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ venv/
 **/config.ini
 .history/
 .vscode/
+.idea/
 .env*
 !.env.sample

--- a/src/main.py
+++ b/src/main.py
@@ -136,11 +136,12 @@ app = FastAPI(title='Reconcile Snow & PRTG', description=desc)
 def sync_site(company_name: str = Form(..., description='Name of Company'), # Ellipsis means it is required
         site_name: str = Form(..., description='Name of Site (Location)'),
         root_id: int = Form(..., description='ID of root group (not to be confused with Probe Device)'),
+        root_is_site: bool = Form(False, description='Set to true if root group is the site'),
         delete: bool = Form(False, description='If true, delete inactive devices. Defaults to false.'),
         email: str | None = Form(None, description='Sends result to email address.'),
         prtg_client: PrtgClient = Depends(custom_prtg_parameters)):
     logger.info(f'Syncing for {company_name} at {site_name}...')
-    logger.debug(f'Company name: {company_name}, Site name: {site_name}, Root ID: {root_id}')
+    logger.debug(f'Company name: {company_name}, Site name: {site_name}, Root ID: {root_id}, Is Root Site: {root_is_site}')
     # clean str inputs
     company_name = html.escape(company_name, quote=False)
     site_name = html.escape(site_name, quote=False)
@@ -158,7 +159,7 @@ def sync_site(company_name: str = Form(..., description='Name of Company'), # El
         logger.info(f'Location "{site_name}" found in SNOW.')
         config_items = snow_controller.get_config_items(company, location)
         try:
-            expected_tree = get_prtg_tree_adapter(company, location, config_items, snow_controller, MIN_DEVICES)
+            expected_tree = get_prtg_tree_adapter(company, location, config_items, snow_controller, root_is_site, MIN_DEVICES)
         except ValueError as e:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
 

--- a/src/main.py
+++ b/src/main.py
@@ -173,6 +173,8 @@ def sync_site(company_name: str = Form(..., description='Name of Company'), # El
             except ObjectNotFound as e:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
         logger.info(f'Group with ID {root_id} found in PRTG.')
+        if group.name != expected_tree.prtg_obj.name:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, f'Root ID {root_id} returns object named "{group.name}" but does not match expected name "{expected_tree.prtg_obj.name}".')
         current_tree = prtg_controller.get_tree(group)
 
         # Sync trees

--- a/src/snow/adapter.py
+++ b/src/snow/adapter.py
@@ -83,15 +83,25 @@ def get_prtg_tree_adapter(company: Company,
                           location: Location,
                           config_items: list[ConfigItem],
                           controller: SnowController,
+                          root_is_site = False,
                           min_device: int = 0) -> Node:
     # Default company's abbreviated name if it exists
     company_name = company.abbreviated_name if company.abbreviated_name else company.name
     # Group format for all groups. Some tools like logging requires a particular format for groups in PRTG.
     group_name_fmt = f'[{company_name}] ' + '{}'
 
-    # instantiate root node with site/location group
-    root_group = PrtgGroupAdapter(group_name_fmt.format(location.name))
-    root = Node(root_group)
+    if not root_is_site:
+        # Initialize root node
+        root_group = PrtgGroupAdapter(f'[{company_name}]')
+        root = Node(root_group)
+
+        # Initialize site node
+        site_group = PrtgGroupAdapter(group_name_fmt.format(location.name))
+        site = Node(site_group, root)
+    else:
+        # Root is site so do not create separate groups
+        root_group = PrtgGroupAdapter(group_name_fmt.format(location.name))
+        root = site = Node(root_group)
 
     # Required number of devices before organizing devices into groups
     num_devices = controller.get_device_count(company, location)
@@ -99,7 +109,7 @@ def get_prtg_tree_adapter(company: Company,
         # Not enough devices. Ignore structure and simply create devices in site group.
         for ci in config_items:
             ci_adapter = PrtgDeviceAdapter.from_ci(ci, company.prtg_device_name_format)
-            Node(ci_adapter, parent=root)
+            Node(ci_adapter, parent=site)
         return root
 
     # Enough devices to organize into groups
@@ -121,7 +131,7 @@ def get_prtg_tree_adapter(company: Company,
     # First group is based on bool attribute is_internal
     if True in pseudo_tree:
         # Internal devices
-        internal_node = Node(PrtgGroupAdapter(group_name_fmt.format('CC Infrastructure')), parent=root)
+        internal_node = Node(PrtgGroupAdapter(group_name_fmt.format('CC Infrastructure')), parent=site)
         # No more groups required for internal devices, simply add devices
         for _, categories in pseudo_tree[True].items():
             for _, cis in categories.items():
@@ -129,7 +139,7 @@ def get_prtg_tree_adapter(company: Company,
                     Node(PrtgDeviceAdapter.from_ci(ci, company.prtg_device_name_format), parent=internal_node)
     if False in pseudo_tree:
         # Customer managed devices
-        external_node = Node(PrtgGroupAdapter(group_name_fmt.format('Customer Managed Infrastructure')), parent=root)
+        external_node = Node(PrtgGroupAdapter(group_name_fmt.format('Customer Managed Infrastructure')), parent=site)
         for stage, categories in pseudo_tree[False].items():
             stage_node = Node(PrtgGroupAdapter(group_name_fmt.format(stage)), parent=external_node)
             for category, cis in categories.items():

--- a/src/sync.py
+++ b/src/sync.py
@@ -97,7 +97,10 @@ def sync_device(expected_path: tuple[Node], current_controller: PrtgController, 
             root = current_controller.get_group_by_name(root_node.prtg_obj.name)
         except ValueError:
             # could be a probe
-            root = current_controller.get_probe_by_name(root_node.prtg_obj.name)
+            try:
+                root = current_controller.get_probe_by_name(root_node.prtg_obj.name)
+            except ValueError:
+                raise RootMismatchException(f'Cannot find expected root group/probe named "{root_node.prtg_obj.name}".')
         existing_group = root
     else:
         existing_group = root_group

--- a/src/sync.py
+++ b/src/sync.py
@@ -36,7 +36,7 @@ def sync_trees(expected: Node,
     devices_added = []
     current_devices_ids = {node.prtg_obj.id for node in current_devices}
     for node in expected_devices:
-        device = sync_device(node.path, current_controller, expected_controller)
+        device = sync_device(node.path, current_controller, expected_controller, root_group=current.prtg_obj)
         if node.prtg_obj.id is None or node.prtg_obj.id not in current_devices_ids:
             devices_added.append(device)
         node.prtg_obj.id = device.id  # update ID before deleting inactive devices
@@ -67,7 +67,7 @@ def sync_trees(expected: Node,
     return devices_added, devices_deleted
 
 
-def sync_device(expected_path: tuple[Node], current_controller: PrtgController, expected_controller: SnowController) -> Device:
+def sync_device(expected_path: tuple[Node], current_controller: PrtgController, expected_controller: SnowController, root_group = None) -> Device:
     """Synchronize a given device: (1) create groups, if necessary, (2) update device details, (3) move device if necessary, 
     and (4) remove last group if empty. If device does not exist, simply create device and any intermediate groups if necessary.
 
@@ -92,12 +92,15 @@ def sync_device(expected_path: tuple[Node], current_controller: PrtgController, 
 
     # require root node to exist
     root_node = next(expected_node_iter)
-    try:
-        root = current_controller.get_group_by_name(root_node.prtg_obj.name)
-    except ValueError:
-        # could be a probe
-        root = current_controller.get_probe_by_name(root_node.prtg_obj.name)
-    existing_group = root
+    if not root_group:
+        try:
+            root = current_controller.get_group_by_name(root_node.prtg_obj.name)
+        except ValueError:
+            # could be a probe
+            root = current_controller.get_probe_by_name(root_node.prtg_obj.name)
+        existing_group = root
+    else:
+        existing_group = root_group
 
     # (1) create any intermediate (non-root) groups as necessary
     groups_to_create = []


### PR DESCRIPTION
Bug found where passing any existing group ID for the root ID worked as long as the expected root ID was found. Fix by forcing a check to ensure the root name matches and raising a detailed exception of the mismatch. This better explains the purpose of root_is_site.